### PR TITLE
도메인 모델과 동작확인

### DIFF
--- a/src/main/java/study/datajpa/entity/Member.java
+++ b/src/main/java/study/datajpa/entity/Member.java
@@ -3,17 +3,31 @@ package study.datajpa.entity;
 
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString(of ={"id", "username", "age"}) // team 적으면 큰일난다. 연관관계 필드는 tosTring 안하는것이 좋다.
 public class Member {
-    @Id @GeneratedValue
+    @Id
+    @GeneratedValue
+    @Column(name = "member_id")
     private Long id;
+
     private String username;
+
+    private int age;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+
+    public void changeTeam(Team team) {
+        this.team = team;
+        team.getMembers().add(this); // team 에 있는 member 에게도 setting 을 해줘야한다. 객체이기 때문에 양쪽에서 바꿔줘야한다.
+    }
 }

--- a/src/main/java/study/datajpa/entity/Team.java
+++ b/src/main/java/study/datajpa/entity/Team.java
@@ -1,0 +1,29 @@
+package study.datajpa.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(of ={"id", "name"})
+@AllArgsConstructor
+public class Team {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "team_id")
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "team")
+    private List<Member> members = new ArrayList<>();
+
+
+}

--- a/src/test/java/study/datajpa/entity/MemberTest.java
+++ b/src/test/java/study/datajpa/entity/MemberTest.java
@@ -1,0 +1,77 @@
+package study.datajpa.entity;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import java.util.List;
+
+
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class MemberTest {
+
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Test
+    public void testEntity() {
+        Team teamA = Team.builder()
+                .name("teamA").build();
+        Team teamB = Team.builder()
+                .name("teamB").build();
+
+        em.persist(teamA);
+        em.persist(teamB);
+
+        Member member1 = Member.builder()
+                .username("member1")
+                .age(10)
+                .team(teamA)
+                .build();
+
+        Member member2 = Member.builder()
+                .username("member1")
+                .age(20)
+                .team(teamA)
+                .build();
+
+
+        Member member3 = Member.builder()
+                .username("member1")
+                .age(30)
+                .team(teamB)
+                .build();
+
+
+        Member member4 = Member.builder()
+                .username("member1")
+                .age(40)
+                .team(teamB)
+                .build();
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+        em.persist(member4);
+
+        // 초기화
+        em.flush(); // 강제로 insert 쿼리를 다 날려버린다.
+        em.clear();
+
+        // 확인
+        List<Member> members = em.createQuery("select m from Member m", Member.class)
+                .getResultList();
+        for (Member member : members) {
+            System.out.println(member.toString());
+            System.out.println(member.getTeam());
+        }
+    }
+}


### PR DESCRIPTION
### What I learned
- 양방햔 관계에서 한쪽 엔티티의 컬럼이 변경되면, 다른쪽 엔티티의 값도 변경시켜줘야한다.
- Q. joinColumn 은 왜 member 에만 쓰지?
- A. joincolumn 어노테이션은 외래키를 매핑할 때 사용한다. name 속성에는 매핑할 외래키 이름을 지정하는데, Member Entity 에서 team_id 를 외래키의 name 으로 지정했다.
- 즉 Member 테이블은 Team Entity 의 id 필드를 외래키로 지정하겠다는 의미이다.
- 그리고 외래키라는 것을 생각해보면 member 입장에서 team 의 정보를 조회할 때 team_id 를 외래키로 가지는게 바람직하지, team 입장에서 다(N)에 해당하는 member_id 를 외래키로 가질 필요가 없다. 